### PR TITLE
Sets project to use Node 10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "node": "~10"
+  },
   "scripts": {
     "dev": "now dev",
     "deploy": "now deploy",


### PR DESCRIPTION
Based on the [docs for
Now](https://zeit.co/docs/builders/#official-builders/node-js/node-js-version)
by default, Now will use Node 8. However, they added support for Node 10
if you specify the engine.

This commit specifies the Node 10 engine in `package.json`. This uses a
more fuzzy matching for the version, since I think Now will use whatever
version of 10 their buiders are set to use.