### PR TITLE
Updates `weekly-summary-typescript` dep to 1.0.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,9 +35,10 @@ export default async function(
   console.log("Requesting Pull Requests");
   let recentlyClosedPullRequests: IPullRequestsForRepos;
   try {
-    recentlyClosedPullRequests = await pullRequestFetcher({
-      organization
-    });
+    recentlyClosedPullRequests = await pullRequestFetcher(
+      { organization },
+      process.env.GITHUB_AUTH_TOKEN
+    );
   } catch (e) {
     res.statusCode = 400;
     res.end(`Failed to fetch pull requests. Received: ${e}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,46 +382,75 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.3.tgz",
-      "integrity": "sha512-ePx9kcUo0agRk0HaXhl+pKMXpBH1O3CAygwWIh7GT5i5kcUr8QowS0GBaZPirr1e0PqaFYr41hQfcUBA1R5AEQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
+      "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
       "requires": {
-        "deepmerge": "3.2.0",
+        "@octokit/types": "^2.0.0",
         "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^2.1.0",
-        "url-template": "^2.0.8"
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
       }
     },
     "@octokit/graphql": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.1.2.tgz",
-      "integrity": "sha512-Vq+Ypj0rQNpeyvh3dhqyyOItyr4KUW4Zu/tdg00PQdlH/iOX+RJQBcDMRMg1oGwY5g2zVtXuhSMFCgR6QoujxA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.1.3.tgz",
+      "integrity": "sha512-XoXJqL2ondwdnMIW3wtqJWEwcBfKk37jO/rYkoxNPEVeLBDGsGO1TCWggrAlq3keGt/O+C/7VepXnukUxwt5vA==",
       "requires": {
-        "@octokit/request": "^4.1.0",
+        "@octokit/request": "^5.0.0",
         "universal-user-agent": "^2.0.3"
       }
     },
     "@octokit/request": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.0.tgz",
-      "integrity": "sha512-RvpQAba4i+BNH0z8i0gPRc1ShlHidj4puQjI/Tno6s+Q3/Mzb0XRSHJiOhpeFrZ22V7Mwjq1E7QS27P5CgpWYA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
       "requires": {
-        "@octokit/endpoint": "^5.1.0",
+        "@octokit/endpoint": "^5.5.0",
         "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^2.1.0"
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
       }
     },
     "@octokit/request-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.2.tgz",
-      "integrity": "sha512-T9swMS/Vc4QlfWrvyeSyp/GjhXtYaBzCcibjGywV4k4D2qVrQKfEMPy8OxMDEj7zkIIdpHwqdpVbKCvnUPqkXw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
+      "integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
       "requires": {
+        "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-YDYgV6nCzdGdOm7wy43Ce8SQ3M5DMKegB8E5sTB/1xrxOdo2yS/KgUgML2N2ZGD621mkbdrAglwTyA4NDOlFFA==",
+      "requires": {
+        "@types/node": ">= 8"
       }
     },
     "@sendgrid/client": {
@@ -1288,11 +1317,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "deepmerge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
-      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1361,9 +1385,9 @@
       "dev": true
     },
     "deprecation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.0.0.tgz",
-      "integrity": "sha512-lbQN037mB3VfA2JFuguM5GCJ+zPinMeCrFe+AfSZ6eqrnJA/Fs+EYMnd6Nb2mn9lf2jO9xwEd9o9lic+D4vkcw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -1377,11 +1401,6 @@
       "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
       "dev": true
     },
-    "docopt": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
-      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE="
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1389,15 +1408,6 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "dot-json": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dot-json/-/dot-json-1.1.0.tgz",
-      "integrity": "sha512-PiQZW9/C8xILPYK2bOye/cbPZrakNEkt28jFb8RlPCwsoMAHYYw9T8JoACxgttHL9Y2AmdqVvibbZJHtLgeqTQ==",
-      "requires": {
-        "docopt": "~0.6.2",
-        "underscore-keypath": "~0.0.22"
       }
     },
     "ecc-jsbn": {
@@ -3437,9 +3447,9 @@
       }
     },
     "macos-release": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
-      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -5028,19 +5038,6 @@
         "source-map": "~0.6.1"
       }
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
-    "underscore-keypath": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/underscore-keypath/-/underscore-keypath-0.0.22.tgz",
-      "integrity": "sha1-SKUoOSu278QkvhyqVtpLX6zPJk0=",
-      "requires": {
-        "underscore": "*"
-      }
-    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -5159,11 +5156,6 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -5236,13 +5228,12 @@
       "dev": true
     },
     "weekly-summary-typescript": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/weekly-summary-typescript/-/weekly-summary-typescript-0.1.1.tgz",
-      "integrity": "sha512-Z0sxpoNoHqgC7PpD2UrdWPKVTaWee9deSe9K9QHCCNhXslx2yydB3j4i85eYo85KBOliyZRpGr6mxa02aHXidQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/weekly-summary-typescript/-/weekly-summary-typescript-1.0.1.tgz",
+      "integrity": "sha512-aXcPtcHrCGbv+1n2/cVSg5nnjirrYhP1A5hys6RLqkagE9jMK1KfysqlZT1atauCbalAWu3N3+Sc6ruqXIRZqQ==",
       "requires": {
-        "@octokit/graphql": "^2.1.1",
-        "date-fns": "^1.30.1",
-        "dot-json": "^1.1.0"
+        "@octokit/graphql": "^2.1.3",
+        "date-fns": "^1.30.1"
       }
     },
     "whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "@sendgrid/mail": "^6.4.0",
     "marked": "~0.6.2",
-    "weekly-summary-typescript": "^0.1.1"
+    "weekly-summary-typescript": "^1.0.0"
   }
 }


### PR DESCRIPTION
The `weekly-summary-typescript` package is what does all of the work for
retrieving the recently closed pull requests. It's [1.0.0
release](https://github.com/tmr08c/weekly-summary-typescript/releases/tag/v1.0.0)
has a breaking change where you not have to explicitly pass in the
GitHub auth token, instead of needing to have it set as a specific
environment  variable. Fortunately, this change was pretty
straightforward for this project.